### PR TITLE
Fix for duplicate symbol problem

### DIFF
--- a/src/cosma/multiply.hpp
+++ b/src/cosma/multiply.hpp
@@ -11,7 +11,7 @@
 #include <cosma/strategy.hpp>
 
 // grid2grid
-#include <transform.cpp>
+#include <transform.hpp>
 
 namespace cosma {
 


### PR DESCRIPTION
A source file was included instead of its header.