### PR TITLE
skip benchmarks if using openblas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,6 @@ if(COSMA_WITH_APPS)
     add_subdirectory(miniapp)
 endif()
 
-if(COSMA_WITH_BENCHMARKS)
+if(COSMA_WITH_BENCHMARKS AND NOT COSMA_WITH_OPENBLAS)
     add_subdirectory(benchmarks)
 endif()


### PR DESCRIPTION
`benchmark/transpose.cpp` is calling mkl functions.