### PR TITLE
use custom FindOpenBLAS.cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ option(COSMA_WITH_BENCHMARKS "Generate the benchmark targets." ${MASTER_PROJECT}
 option(COSMA_WITH_INSTALL "Enable installation." ${MASTER_PROJECT})
 option(COSMA_WITH_PROFILING "Enable profiling." OFF)
 
-set(COSMA_BLAS "MKL" CACHE STRING 
+set(COSMA_BLAS "MKL" CACHE STRING
     "Blas backend. Can be MKL, OPENBLAS, CRAY_LIBSCI, CUSTOM, CUDA or ROCM.")
-set_property(CACHE COSMA_BLAS PROPERTY STRINGS 
+set_property(CACHE COSMA_BLAS PROPERTY STRINGS
     "MKL" "OPENBLAS" "CRAY_LIBSCI" "CUSTOM" "CUDA" "ROCM")
 
 set(COSMA_SCALAPACK "OFF" CACHE STRING
@@ -81,17 +81,13 @@ if (${COSMA_BLAS} STREQUAL "MKL")
     set(BLAS_TARGET "mkl::blas_32bit_omp")
     set(BLAS_DEF "COSMA_WITH_MKL_BLAS")
 elseif (${COSMA_BLAS} STREQUAL "CUDA" OR ${COSMA_BLAS} STREQUAL "ROCM")
-    option(TILEDMM_WITH_INSTALL "" ${COSMA_WITH_INSTALL}) 
+    option(TILEDMM_WITH_INSTALL "" ${COSMA_WITH_INSTALL})
     set(TILEMM_GPU_BACKEND ${COSMA_BLAS} CACHE STRING FORCE "")
     add_subdirectory(libs/Tiled-MM)
     set(BLAS_TARGET "Tiled-MM")
     set(BLAS_DEF "COSMA_HAVE_GPU")
 elseif (${COSMA_BLAS} STREQUAL "OPENBLAS")
     find_package(OpenBLAS REQUIRED)
-    add_library(openblas STATIC IMPORTED)
-    set_target_properties(openblas PROPERTIES 
-                                   INTERFACE_INCLUDE_DIRECTORIES "${OpenBLAS_INCLUDE_DIRS}"
-                                   IMPORTED_LOCATION "${OpenBLAS_LIBRARIES}")
     set(BLAS_TARGET "openblas")
     set(BLAS_DEF "COSMA_WITH_BLAS")
 elseif (${COSMA_BLAS} STREQUAL "CRAY_LIBSCI")
@@ -104,7 +100,7 @@ elseif (${COSMA_BLAS} STREQUAL "CUSTOM")
     set(BLAS_DEF "COSMA_WITH_BLAS")
 endif ()
 
-# (optional) ScaLAPACK providers 
+# (optional) ScaLAPACK providers
 #
 set(ScaLAPACK_TARGET "")
 if (${COSMA_SCALAPACK} STREQUAL "MKL")
@@ -128,9 +124,9 @@ if(COSMA_WITH_INSTALL)
     include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
 
-    install(DIRECTORY "${cosma_SOURCE_DIR}/src/cosma" 
+    install(DIRECTORY "${cosma_SOURCE_DIR}/src/cosma"
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-            FILES_MATCHING 
+            FILES_MATCHING
                 PATTERN "*.hpp")
 
     write_basic_package_version_file(

--- a/cmake/FindOpenBLAS.cmake
+++ b/cmake/FindOpenBLAS.cmake
@@ -1,0 +1,29 @@
+# find OpenBLAS
+# workaround for missing openblas cmake config file in fedora
+
+include(FindPackageHandleStandardArgs)
+
+find_path(OPENBLAS_INCLUDE_DIR
+  NAMES lapack.h
+  PATH_SUFFIXES include
+  HINTS
+  ENV OPENBLAS_DIR
+  ENV OPENBLASROOT
+  DOC "openblas include directory")
+
+find_library(OPENBLAS_LIBRARIES
+  NAMES openblas
+  PATH_SUFFIXES lib lib64
+  HINTS
+  ENV OPENBLAS_DIR
+  ENV OPENBLASROOT
+  DOC "openblas libraries list")
+
+find_package_handle_standard_args(OpenBLAS DEFAULT_MSG OPENBLAS_LIBRARIES OPENBLAS_INCLUDE_DIR)
+
+if(OpenBLAS_FOUND AND NOT TARGET openblas)
+  add_library(openblas INTERFACE IMPORTED)
+  set_target_properties(openblas PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${OPENBLAS_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${OPENBLAS_LIBRARIES}")
+endif()


### PR DESCRIPTION
- some distros, at least fedora (*), do not include the cmake config
  file of openblas in their packages
- remove trailing whitespace in `CMakeLists.txt`

The following environment variables can be set as a hint to locate openblas:
 - `OPENBLAS_DIR`
 - `OPENBLASROOT`

(*):  fedora openblas-devel pkg: https://koji.fedoraproject.org/koji/rpminfo?rpmID=20778908