### PR TITLE
Upload archives including dependencies on releases

### DIFF
--- a/.github/workflows/tarball_dependencies_on_release.yml
+++ b/.github/workflows/tarball_dependencies_on_release.yml
@@ -1,0 +1,50 @@
+name: Release tarballs
+
+on: 
+  release:
+    types:
+      - created
+
+jobs:
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Get Release
+      id: get
+      uses: bruceadams/get-release@v1.2.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.GITHUB_REF }}
+        submodules: recursive
+        path: sources/cosma
+
+    - name: Create sources tarball
+      run: |
+        GZIP=-9 tar --exclude-vcs -C sources -zcvf cosma.tar.gz cosma
+        zip -9 -x \*.git\* -r cosma.zip sources/cosma
+
+    - name: Upload tar
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get.outputs.upload_url }}
+        asset_path: ./cosma.tar.gz
+        asset_name: cosma.tar.gz
+        asset_content_type: application/gzip
+
+    - name: Upload zip
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.get.outputs.upload_url }}
+        asset_path: ./cosma.zip
+        asset_name: cosma.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
Adds a Github action that creates tar and zip archives
including dependencies and uploads them to new releases.