### PR TITLE
initialize matrix with random numbers

### DIFF
--- a/src/cosma/random_generator.hpp
+++ b/src/cosma/random_generator.hpp
@@ -17,7 +17,7 @@ template <>
 inline int random_generator<int>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_int_distribution<int> dist(10); // distribution
+    static std::uniform_int_distribution<int> dist(0, 10); // distribution
 
     return dist(rng);
 }
@@ -26,7 +26,7 @@ template <>
 inline double random_generator<double>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_real_distribution<double> dist(1.0); // distribution
+    static std::uniform_real_distribution<double> dist(0.0, 1.0); // distribution
 
     return dist(rng);
 }
@@ -35,7 +35,7 @@ template <>
 inline float random_generator<float>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_real_distribution<float> dist(1.0f); // distribution
+    static std::uniform_real_distribution<float> dist(0.0f, 1.0f); // distribution
 
     return dist(rng);
 }
@@ -44,7 +44,7 @@ template <>
 inline std::complex<int> random_generator<std::complex<int>>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_int_distribution<int> dist(10); // distribution
+    static std::uniform_int_distribution<int> dist(0, 10); // distribution
     return {dist(rng), dist(rng)};
 }
 
@@ -52,7 +52,7 @@ template <>
 inline std::complex<float> random_generator<std::complex<float>>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_real_distribution<float> dist(1.0f); // distribution
+    static std::uniform_real_distribution<float> dist(0.0f, 1.0f); // distribution
     return {dist(rng), dist(rng)};
 }
 
@@ -60,7 +60,7 @@ template <>
 inline std::complex<double> random_generator<std::complex<double>>::sample() {
     static std::random_device dev;                        // seed
     static std::mt19937 rng(dev());                       // generator
-    static std::uniform_real_distribution<double> dist(1.0); // distribution
+    static std::uniform_real_distribution<double> dist(0.0, 1.0); // distribution
     return {dist(rng), dist(rng)};
 }
 } // end namespace cosma


### PR DESCRIPTION
This PR fix the data generator problem. Previously COSMA initializes all the matrices with 1.0, which has a better performance than normal cases. (If the server enables turbo boost, the cpu will achieve higher clock rate when all the value of matrices is 1.0)