### PR TITLE
Bumping nvidia container tag from 11.6.0 to 11.6.2

### DIFF
--- a/docker/gpu/build-env.Dockerfile
+++ b/docker/gpu/build-env.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.6.0-devel-ubuntu20.04
+FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
 
 WORKDIR /root
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
NVIDIA [predates](https://github.com/NVIDIA/nvidia-docker/issues/1735) their own images sometimes, and now that happened to 11.6.0, which has been superseded by 11.6.2.