### PR TITLE
Getting the docker container to build and run COSMA tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if (COSMA_WITH_PROFILING)
 endif ()
 
 if (COSMA_WITH_TESTS OR COSMA_WITH_APPS)
-  find_package(cxxopts REQUIRED)
+  add_git_submodule_or_find_external(cxxopts libs/cxxopts)
 endif()
 
 # these are only GPU-backends

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,3 +78,18 @@ Notes:
   add `^mpich`
 
 For more information on Spack: [Spack 101 Tutorial](https://spack.readthedocs.io/en/latest/tutorial.html).
+
+## Docker
+
+COSMA can be installed into a Docker container in the following way:
+
+```
+docker build -f docker/gpu/build-env.Dockerfile -t cosma-build-env .
+docker build --build-arg BUILD_ENV=cosma-build-env -f docker/gpu/deploy.Dockerfile -t cosma .
+```
+
+Then the `cosma` container can be deployed for testing:
+
+```
+docker run --rm -it -v (pwd):(pwd) --gpus all cosma
+```

--- a/docker/asan/build-env.Dockerfile
+++ b/docker/asan/build-env.Dockerfile
@@ -13,7 +13,7 @@ ENV MPICH_VERSION ${MPICH_VERSION}
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     build-essential gfortran pkg-config \
-    git tar wget curl && \
+    git tar wget curl chrpath && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/docker/asan/build-env.Dockerfile
+++ b/docker/asan/build-env.Dockerfile
@@ -55,6 +55,6 @@ RUN wget -qO - http://www.netlib.org/scalapack/scalapack-${NETLIB_SCALAPACK_VERS
 
 # Add deployment tooling
 RUN mkdir -p /opt/libtree && \
-    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v3.0.3/libtree_x86_64 && \
+    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v2.0.0/libtree_x86_64 && \
     chmod +x /opt/libtree/libtree
 

--- a/docker/asan/deploy.Dockerfile
+++ b/docker/asan/deploy.Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /COSMA/build && cd /COSMA/build && \
       make install && \
       rm -rf /COSMA
 
-RUN /root/libtree/libtree \
+RUN /opt/libtree/libtree \
       --chrpath \
       -d /root/COSMA.bundle/ \
       /root/COSMA-build/bin/test.cosma \

--- a/docker/cpu-release/build-env.Dockerfile
+++ b/docker/cpu-release/build-env.Dockerfile
@@ -20,7 +20,7 @@ ENV COSMA_MIN_LOCAL_DIMENSION=32
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
     software-properties-common \
     build-essential \
-    git tar wget curl gpg-agent && \
+    git tar wget curl gpg-agent chrpath && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/docker/cpu-release/build-env.Dockerfile
+++ b/docker/cpu-release/build-env.Dockerfile
@@ -44,6 +44,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
 
 # Add deployment tooling
 RUN mkdir -p /opt/libtree && \
-    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v3.0.3/libtree_x86_64 && \
+    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v2.0.0/libtree_x86_64 && \
     chmod +x /opt/libtree/libtree
 

--- a/docker/cpu-release/deploy.Dockerfile
+++ b/docker/cpu-release/deploy.Dockerfile
@@ -20,7 +20,7 @@ RUN source /opt/intel/bin/compilervars.sh intel64 && \
 ENV MKL_LIB=/opt/intel/compilers_and_libraries/linux/mkl/lib/intel64
 
 # Run linuxdeploy, and add a bunch of libs that are dlopen'ed by mkl
-RUN /root/libtree/libtree --chrpath --strip -d /root/COSMA.bundle/ \
+RUN /opt/libtree/libtree --chrpath --strip -d /root/COSMA.bundle/ \
       /root/COSMA-build/bin/test.cosma \
       /root/COSMA-build/bin/test.mapper \
       /root/COSMA-build/bin/test.multiply \

--- a/docker/gpu/build-env.Dockerfile
+++ b/docker/gpu/build-env.Dockerfile
@@ -61,6 +61,6 @@ RUN wget -qO - http://www.netlib.org/scalapack/scalapack-${NETLIB_SCALAPACK_VERS
 
 # Add deployment tooling
 RUN mkdir -p /opt/libtree && \
-    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v3.0.3/libtree_x86_64 && \
+    curl -Lfso /opt/libtree/libtree https://github.com/haampie/libtree/releases/download/v2.0.0/libtree_x86_64 && \
     chmod +x /opt/libtree/libtree
 

--- a/docker/gpu/build-env.Dockerfile
+++ b/docker/gpu/build-env.Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -qq && \
     apt-get install -qq -y --no-install-recommends \
       software-properties-common \
       build-essential gfortran pkg-config \
-      git tar wget curl && \
+      git tar wget curl chrpath && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cmake

--- a/docker/gpu/deploy.Dockerfile
+++ b/docker/gpu/deploy.Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /COSMA/build && cd /COSMA/build && \
       rm -rf /COSMA
 
 # Run linuxdeploy, and add a bunch of libs that are dlopen'ed by mkl
-RUN /root/libtree/libtree \
+RUN /opt/libtree/libtree \
       -d /root/COSMA.bundle/ \
       --chrpath \
       --strip \


### PR DESCRIPTION
This set of small changes is required, in order to get the Docker containers to build successfully:

 * Use submodule for `cxxopts` if not available externally, in the same way as it is done for the other dependencies
 * Correcting libtree path, which is installed to `/opt`, not to `/root`
 * Must use libtree `v2.0.0`, which is the last version where the required `--chrpath` functionality is available; by some reason, the libtree author decided to remove it in `v3.*`
 * Must provide `chrpath` package, which the use of libtree depends on

I'm also adding an `INSTALL.md` note about COSMA installation and testing in Docker.