### PR TITLE
Fix minor compilations issues with rocm 6 and spack

### DIFF
--- a/src/cosma/communicator.hpp
+++ b/src/cosma/communicator.hpp
@@ -16,7 +16,7 @@
 #endif
 
 #if defined(COSMA_WITH_NCCL) && defined(TILED_MM_ROCM)
-#include <rccl.h>
+#include <rccl/rccl.h>
 #endif
 
 namespace cosma {

--- a/src/cosma/gpu/nccl_mapper.hpp
+++ b/src/cosma/gpu/nccl_mapper.hpp
@@ -6,7 +6,7 @@
 #include <nccl.h>
 
 #elif defined(TILED_MM_ROCM)
-#include <rccl.h>
+#include <rccl/rccl.h>
 
 #else
 #error Either TILED_MM_CUDA or TILED_MM_ROCM must be defined!

--- a/src/cosma/gpu/nccl_utils.hpp
+++ b/src/cosma/gpu/nccl_utils.hpp
@@ -10,7 +10,7 @@
 #include <nccl.h>
 
 #elif defined(TILED_MM_ROCM)
-#include <rccl.h>
+#include <rccl/rccl.h>
 
 #else
 #error Either TILED_MM_CUDA or TILED_MM_ROCM must be defined!


### PR DESCRIPTION
- Remove the CMAKE_MPICXX_* from the CosmaConfig.cmake.in template
- Fix include path for rccl.h