### PR TITLE
remove C from languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cosma
   DESCRIPTION "Communication Optimal Matrix Multiplication"
   HOMEPAGE_URL "https://github.com/eth-cscs/COSMA"
   VERSION 2.6.6
-  LANGUAGES CXX C)
+  LANGUAGES CXX)
 
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 # Dependencies
 # MPI
 set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
-find_package(MPI COMPONENTS CXX C REQUIRED)
+find_package(MPI COMPONENTS CXX REQUIRED)
 adjust_mpiexec_flags()
 
 if (NOT COSMA_SCALAPACK MATCHES "OFF")


### PR DESCRIPTION
the project is written in C++, the Fortran and C interface is also
created from a C++ source file wrapped in `extern "C" { ... }` so I
think a C compiler shouldn't be required to build this.

Note: I did not test this PR.